### PR TITLE
Backend Url in Env

### DIFF
--- a/app/lib/useFetchApiData.jsx
+++ b/app/lib/useFetchApiData.jsx
@@ -3,9 +3,10 @@ import {useEffect, useState} from "react";
 export function useFetchApiData(user, path, method) {
     const [data, setData] = useState([]);
     const [error, setError] = useState(null);
-
+    const backend_url = process.env.NEXT_PUBLIC_BACKEND_URL
     useEffect(() => {
         const fetchProtectedData = async () => {
+            console.log(backend_url)
             try {
                 if (!user) {
                     console.log('User is not logged in');
@@ -19,7 +20,8 @@ export function useFetchApiData(user, path, method) {
                 console.log('Token:', accessToken);
 
                 // Use the token to access the protected backend route
-                const response = await fetch(`http://localhost:3001/${path}`, {
+
+                const response = await fetch(`${backend_url}${path}`, {
                     method, // Directly use the method string
                     headers: {
                         Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
Die Backend-Url ist jetzt in den Env, damit muss man nicht neu Deployed, wenn sich was ändert.
Dadurch bessere Wartbarkeit