### PR TITLE
Fix für .env mit Backend-URL

### DIFF
--- a/app/lib/useFetchApiData.jsx
+++ b/app/lib/useFetchApiData.jsx
@@ -3,10 +3,11 @@ import {useEffect, useState} from "react";
 export function useFetchApiData(user, path, method) {
     const [data, setData] = useState([]);
     const [error, setError] = useState(null);
+    let backend_url
     if (process.env.NEXT_PUBLIC_BACKEND_URL === '') {
-        const backend_url = "https://eventplanner.azurewebsites.net/"
+        backend_url = "https://eventplanner-backend.azurewebsites.net/"
     } else {
-        const backend_url = process.env.NEXT_PUBLIC_BACKEND_URL
+        backend_url = process.env.NEXT_PUBLIC_BACKEND_URL
     }
     useEffect(() => {
         const fetchProtectedData = async () => {

--- a/app/lib/useFetchApiData.jsx
+++ b/app/lib/useFetchApiData.jsx
@@ -3,7 +3,11 @@ import {useEffect, useState} from "react";
 export function useFetchApiData(user, path, method) {
     const [data, setData] = useState([]);
     const [error, setError] = useState(null);
-    const backend_url = process.env.NEXT_PUBLIC_BACKEND_URL
+    if (process.env.NEXT_PUBLIC_BACKEND_URL === '') {
+        const backend_url = "https://eventplanner.azurewebsites.net/"
+    } else {
+        const backend_url = process.env.NEXT_PUBLIC_BACKEND_URL
+    }
     useEffect(() => {
         const fetchProtectedData = async () => {
             console.log(backend_url)


### PR DESCRIPTION
Das ist ein Hotfix, den ich so gerne direkt in Main pushen würde. Die Idee ist, das damit endlich die Variable für das Backend funktioniert. Das ganze ist aktuell so, das wenn der Wert leer ist, ein Fallback verwendet wird