### PR TITLE
Tippfehler API-Route beseitigt

### DIFF
--- a/app/[instanz]/[organisation]/[user]/users/page.jsx
+++ b/app/[instanz]/[organisation]/[user]/users/page.jsx
@@ -6,7 +6,7 @@ import {useFetchApiData} from "../../../../lib/useFetchApiData";
 
 function App() {
     const { user, error: authError, isLoading } = useUser();
-    const path = "api/users";
+    const path = "/api/users";
     const method = 'GET';
     const {data: users, error: fetchError} = useFetchApiData(user, path, method);
 


### PR DESCRIPTION
Aufgrund der Tatsache, das azure kein "/" mag, wurde hier die Route angepasst. Sollte jetzt gehen