### PR TITLE
Dateipfade ab Projekt root statt relativ zur Datei

### DIFF
--- a/app/[instanz]/[organisation]/[user]/announcements/page.js
+++ b/app/[instanz]/[organisation]/[user]/announcements/page.js
@@ -4,17 +4,17 @@ import React, { useState, useEffect } from 'react';
 import { 
   Paper, TextField, Box, Stack, Autocomplete, 
 } from '@mui/material';
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 import {StyledTableContainer, 
    StyledTable, 
    StyledTableRow,
    StyledTableHeadCell,
    StyledTableBody,
    StyledTableCell, 
-   StyledTableHead } from "../../../../components/styledComponents/StyledTable";
-import { useUserContext } from "../../../../context/UserContext"; // Benutzerkontext importieren
+   StyledTableHead } from "@/app/components/styledComponents/StyledTable";
+import { useUserContext } from "@/app/context/UserContext"; // Benutzerkontext importieren
 import { useRouter } from 'next/navigation';
 
 const data = [

--- a/app/[instanz]/[organisation]/[user]/announcements/page.js
+++ b/app/[instanz]/[organisation]/[user]/announcements/page.js
@@ -5,7 +5,7 @@ import {
   Paper, TextField, Box, Stack, Autocomplete, 
 } from '@mui/material';
 import StyledPaper from "@/app/components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import { BlueButton, RedButton } from "@/app/components/styledComponents/StyledButton";
 import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 import {StyledTableContainer, 
    StyledTable, 

--- a/app/[instanz]/[organisation]/[user]/create-announcements/page.js
+++ b/app/[instanz]/[organisation]/[user]/create-announcements/page.js
@@ -3,11 +3,11 @@ import {
    Typography, TextField, FormControlLabel,
   Checkbox, Paper, Button
 } from "@mui/material";
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
-import {StyledBox} from "../../../../components/styledComponents/StyledBox";
-import { useUserContext } from "../../../../context/UserContext"; // Benutzerkontext importieren
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
+import {StyledBox} from "@/app/components/styledComponents/StyledBox";
+import { useUserContext } from "@/app/context/UserContext"; // Benutzerkontext importieren
 import React, {useEffect,useState } from 'react';
 import { useRouter } from 'next/navigation';
 

--- a/app/[instanz]/[organisation]/[user]/create-announcements/page.js
+++ b/app/[instanz]/[organisation]/[user]/create-announcements/page.js
@@ -1,10 +1,12 @@
 "use client"
 import {
-   Typography, TextField, FormControlLabel,
-  Checkbox, Paper, Button
+    Typography,
+    TextField,
+    FormControlLabel,
+    Checkbox,
 } from "@mui/material";
 import StyledPaper from "@/app/components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import { GreenButton, RedButton } from "@/app/components/styledComponents/StyledButton";
 import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 import {StyledBox} from "@/app/components/styledComponents/StyledBox";
 import { useUserContext } from "@/app/context/UserContext"; // Benutzerkontext importieren

--- a/app/[instanz]/[organisation]/[user]/createEvent/page.js
+++ b/app/[instanz]/[organisation]/[user]/createEvent/page.js
@@ -5,10 +5,10 @@ import { Box, Button, Typography, TextField, Checkbox, FormControlLabel, InputAd
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import { useRouter } from 'next/navigation';
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
-import { useUserContext } from "../../../../context/UserContext"; // Benutzerkontext importieren
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
+import { useUserContext } from "@/app/context/UserContext"; // Benutzerkontext importieren
 
 function UserDashboard() {
   const [checkedOnline, setCheckedOnline] = useState(false);

--- a/app/[instanz]/[organisation]/[user]/invites/page.js
+++ b/app/[instanz]/[organisation]/[user]/invites/page.js
@@ -3,7 +3,6 @@
 import React, { useState, useEffect } from 'react';
 import {
   Box,
-  Button,
   Table,
   TableBody,
   TableCell,

--- a/app/[instanz]/[organisation]/[user]/invites/page.js
+++ b/app/[instanz]/[organisation]/[user]/invites/page.js
@@ -16,11 +16,11 @@ import {
   InputAdornment,
 } from '@mui/material';
 import FilterListIcon from '@mui/icons-material/FilterList'; // Import the filter icon
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 import { useRouter } from 'next/navigation';
-import { useUserContext } from "../../../../context/UserContext"; // Benutzerkontext importieren
+import { useUserContext } from "@/app/context/UserContext"; // Benutzerkontext importieren
 
 function UserDashboard() {
   const [searchText, setSearchText] = useState('');

--- a/app/[instanz]/[organisation]/[user]/layout.js
+++ b/app/[instanz]/[organisation]/[user]/layout.js
@@ -1,5 +1,5 @@
-import "../../../globals.css";
-import Sidebar from "../../../components/Sidebar";
+import "@/app/globals.css";
+import Sidebar from "@/app/components/Sidebar";
 import { Box } from "@mui/material";
 
 export const metadata = {

--- a/app/[instanz]/[organisation]/[user]/meinEntwurf/page.js
+++ b/app/[instanz]/[organisation]/[user]/meinEntwurf/page.js
@@ -2,7 +2,6 @@
 import React, { useState, useEffect } from "react";
 import {
   Box,
-  Button,
   IconButton,
   Grid,
   ToggleButton,
@@ -18,7 +17,7 @@ import GridIcon from "@mui/icons-material/ViewModule";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import StyledPaper from "@/app/components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import { BlueButton } from "@/app/components/styledComponents/StyledButton";
 import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 
 function MeinEntwurf() {

--- a/app/[instanz]/[organisation]/[user]/meinEntwurf/page.js
+++ b/app/[instanz]/[organisation]/[user]/meinEntwurf/page.js
@@ -17,9 +17,9 @@ import ListIcon from "@mui/icons-material/ViewList";
 import GridIcon from "@mui/icons-material/ViewModule";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 
 function MeinEntwurf() {
   const [view, setView] = useState("list");

--- a/app/[instanz]/[organisation]/[user]/myevent/page.js
+++ b/app/[instanz]/[organisation]/[user]/myevent/page.js
@@ -6,7 +6,6 @@ import {
   Button,
   ToggleButton,
   ToggleButtonGroup,
-  Typography,
   Link,
   Paper,
   Badge,
@@ -24,7 +23,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import EventIcon from '@mui/icons-material/Event';
 import { useRouter } from 'next/navigation';
 import StyledPaper from "@/app/components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import { BlueButton } from "@/app/components/styledComponents/StyledButton";
 import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 
 

--- a/app/[instanz]/[organisation]/[user]/myevent/page.js
+++ b/app/[instanz]/[organisation]/[user]/myevent/page.js
@@ -23,9 +23,9 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EventIcon from '@mui/icons-material/Event';
 import { useRouter } from 'next/navigation';
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 
 
 function EventCard({ count, view }) {

--- a/app/[instanz]/[organisation]/[user]/notification/page.js
+++ b/app/[instanz]/[organisation]/[user]/notification/page.js
@@ -6,10 +6,10 @@ import {
   Paper, Typography, Button, TextField, Menu, MenuItem, IconButton
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import { BlueButton, RedButton } from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
-import { useDarkMode } from "../../../../components/styledComponents/DarkMode"; // Importiere den DarkMode-Status
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import { BlueButton, RedButton } from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
+import { useDarkMode } from "@/app/components/styledComponents/DarkMode"; // Importiere den DarkMode-Status
 
 const initialEmails = [
   { subject: 'System Update Notification', sender: 'admin@system.com', date: '2024-11-01', status: 'Unread', body: 'System update scheduled for 2024-11-02.' },

--- a/app/[instanz]/[organisation]/[user]/notification/page.js
+++ b/app/[instanz]/[organisation]/[user]/notification/page.js
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import {
   Box, Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
-  Paper, Typography, Button, TextField, Menu, MenuItem, IconButton
+  Paper, Typography, TextField, Menu, MenuItem, IconButton
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import StyledPaper from "@/app/components/styledComponents/StyledPaper";

--- a/app/[instanz]/[organisation]/[user]/preview/page.js
+++ b/app/[instanz]/[organisation]/[user]/preview/page.js
@@ -20,9 +20,9 @@ import FacebookIcon from "@mui/icons-material/Facebook";
 import InstagramIcon from "@mui/icons-material/Instagram";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 
 function EventDetails() {
     return (

--- a/app/[instanz]/[organisation]/[user]/preview/page.js
+++ b/app/[instanz]/[organisation]/[user]/preview/page.js
@@ -4,8 +4,6 @@ import React from "react";
 import {
   Box,
   Typography,
-  Button,
-  TextField,
   Grid,
   Card,
   CardContent,
@@ -21,7 +19,7 @@ import InstagramIcon from "@mui/icons-material/Instagram";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import StyledPaper from "@/app/components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import { GreenButton } from "@/app/components/styledComponents/StyledButton";
 import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 
 function EventDetails() {

--- a/app/[instanz]/[organisation]/[user]/profile/page.js
+++ b/app/[instanz]/[organisation]/[user]/profile/page.js
@@ -2,9 +2,9 @@
 
 import React, { useState } from 'react';
 import { Box, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Button, TextField, Avatar, Typography, Paper } from '@mui/material';
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 
 function UserProfile() {
   const [openSaveDialog, setOpenSaveDialog] = useState(false);

--- a/app/[instanz]/[organisation]/[user]/profile/page.js
+++ b/app/[instanz]/[organisation]/[user]/profile/page.js
@@ -1,9 +1,9 @@
 "use client";
 
 import React, { useState } from 'react';
-import { Box, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Button, TextField, Avatar, Typography, Paper } from '@mui/material';
+import { Box, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Button, TextField, Avatar } from '@mui/material';
 import StyledPaper from "@/app/components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "@/app/components/styledComponents/StyledButton";
+import { BlueButton, GreenButton } from "@/app/components/styledComponents/StyledButton";
 import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 
 function UserProfile() {

--- a/app/[instanz]/[organisation]/[user]/settings/page.js
+++ b/app/[instanz]/[organisation]/[user]/settings/page.js
@@ -3,10 +3,10 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Button, Typography, Paper, FormControl, InputLabel, MenuItem, Select, Stack } from '@mui/material';
 import { useRouter } from 'next/navigation';
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton, ToggleButton} from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
-import { useUserContext } from "../../../../context/UserContext"; // Benutzerkontext importieren
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import {BlueButton,GreenButton ,RedButton, ToggleButton} from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
+import { useUserContext } from "@/app/context/UserContext"; // Benutzerkontext importieren
 
 function UserSettings() {
   const router = useRouter();

--- a/app/[instanz]/[organisation]/[user]/settings/page.js
+++ b/app/[instanz]/[organisation]/[user]/settings/page.js
@@ -1,10 +1,10 @@
 "use client";
 
 import React, { useState, useEffect } from 'react';
-import { Box, Button, Typography, Paper, FormControl, InputLabel, MenuItem, Select, Stack } from '@mui/material';
+import { Box, Paper, FormControl, InputLabel, MenuItem, Select, Stack } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import StyledPaper from "@/app/components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton, ToggleButton} from "@/app/components/styledComponents/StyledButton";
+import { GreenButton, RedButton, ToggleButton} from "@/app/components/styledComponents/StyledButton";
 import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 import { useUserContext } from "@/app/context/UserContext"; // Benutzerkontext importieren
 

--- a/app/[instanz]/[organisation]/[user]/termin/page.js
+++ b/app/[instanz]/[organisation]/[user]/termin/page.js
@@ -11,12 +11,12 @@ import {
 import { Calendar, momentLocalizer, Views } from "react-big-calendar";
 import moment from "moment";
 import "react-big-calendar/lib/css/react-big-calendar.css";
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import { RedButton, BlueButton, GreenButton } from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import { RedButton, BlueButton, GreenButton } from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 import jsPDF from "jspdf"; // Für PDF-Generierung
 import { saveAs } from "file-saver"; // Für .ics-Datei
-import {CustomToolbar, formats, germanMessages} from "../../../../components/styledComponents/StyledCalender"
+import {CustomToolbar, formats, germanMessages} from "@/app/components/styledComponents/StyledCalender"
 
 moment.locale("de");
 

--- a/app/[instanz]/[organisation]/[user]/userControl/page.js
+++ b/app/[instanz]/[organisation]/[user]/userControl/page.js
@@ -19,9 +19,8 @@ import {
   DialogTitle,
   Typography,
 } from "@mui/material";
-import StyledPaper from "../../../../components/styledComponents/StyledPaper";
-import {BlueButton,GreenButton ,RedButton} from "../../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../../components/styledComponents/DesignTitel";
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 
 const UserControl = () => {
   const [users, setUsers] = useState([]); // Benutzerliste

--- a/app/[instanz]/[organisation]/[user]/users/page.jsx
+++ b/app/[instanz]/[organisation]/[user]/users/page.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import {useUser} from '@auth0/nextjs-auth0/client';
-import {useFetchApiData} from "../../../../lib/useFetchApiData";
+import {useFetchApiData} from "@/app/lib/useFetchApiData";
 
 function App() {
     const { user, error: authError, isLoading } = useUser();

--- a/app/components/LogInOut.jsx
+++ b/app/components/LogInOut.jsx
@@ -6,8 +6,8 @@ import { Box, Link, Typography } from '@mui/material';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
-import Footer from '../components/Footer';
-import { BlueButton, RedButton, GreenButton } from '../components/styledComponents/StyledButton';
+import Footer from '@/app/components/Footer';
+import { BlueButton, RedButton, GreenButton } from '@/app/components/styledComponents/StyledButton';
 
 const LogInOut = () => {
   const { user, isLoading } = useUser();

--- a/app/components/Sidebar.js
+++ b/app/components/Sidebar.js
@@ -2,8 +2,8 @@
 
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import SidebarDesign from "../components/styledComponents/SidebarDesign";
-import { useUserContext } from "../context/UserContext"; // Benutzerkontext
+import SidebarDesign from "@/app/components/styledComponents/SidebarDesign";
+import { useUserContext } from "@/app/context/UserContext"; // Benutzerkontext
 
 function Sidebar() {
   const [isExpanded, setIsExpanded] = useState(false);

--- a/app/components/SimpleLogin.js
+++ b/app/components/SimpleLogin.js
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Box, TextField, Button, Typography } from '@mui/material';
-import { useUserContext } from '../context/UserContext'; // Benutzerkontext
+import { useUserContext } from '@/app/context/UserContext'; // Benutzerkontext
 
 const SimpleLogin = () => {
   const [loginState, setLoginState] = useState({ username: '', password: '' });

--- a/app/event/[event_id]/participants-message/page.js
+++ b/app/event/[event_id]/participants-message/page.js
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import {
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
-  Paper, TextField, Button, Box, Stack, Typography, InputAdornment, Checkbox
+  Paper, TextField, Box, Stack, InputAdornment, Checkbox
 } from '@mui/material';
 import StyledPaper from "@/app/components/styledComponents/StyledPaper";
 import { BlueButton, GreenButton, RedButton } from "@/app/components/styledComponents/StyledButton";

--- a/app/event/[event_id]/participants-message/page.js
+++ b/app/event/[event_id]/participants-message/page.js
@@ -5,9 +5,9 @@ import {
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
   Paper, TextField, Button, Box, Stack, Typography, InputAdornment, Checkbox
 } from '@mui/material';
-import StyledPaper from "../../../components/styledComponents/StyledPaper";
-import { BlueButton, GreenButton, RedButton } from "../../../components/styledComponents/StyledButton";
-import DesignTitel from "../../../components/styledComponents/DesignTitel";
+import StyledPaper from "@/app/components/styledComponents/StyledPaper";
+import { BlueButton, GreenButton, RedButton } from "@/app/components/styledComponents/StyledButton";
+import DesignTitel from "@/app/components/styledComponents/DesignTitel";
 import FilterListIcon from '@mui/icons-material/FilterList'; // Filter Icon importieren
 
 {/* Beispieldaten */ }

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,8 +1,6 @@
 import "./globals.css";
 
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { UserProvider } from '@auth0/nextjs-auth0/client';
-import {Box} from "@mui/material";
 import { ChatProvider } from "@/app/components/ChatContext";
 import { DarkModeProvider } from "@/app/components/styledComponents/DarkMode"
 import {UserProviderr} from "@/app/context/UserContext"

--- a/app/layout.js
+++ b/app/layout.js
@@ -3,9 +3,9 @@ import "./globals.css";
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { UserProvider } from '@auth0/nextjs-auth0/client';
 import {Box} from "@mui/material";
-import { ChatProvider } from "./components/ChatContext";
-import { DarkModeProvider } from "./components/styledComponents/DarkMode"
-import {UserProviderr} from "./context/UserContext"
+import { ChatProvider } from "@/app/components/ChatContext";
+import { DarkModeProvider } from "@/app/components/styledComponents/DarkMode"
+import {UserProviderr} from "@/app/context/UserContext"
 
 export const metadata = {
   title: "Veranstaltungsplaner",

--- a/app/page.js
+++ b/app/page.js
@@ -1,4 +1,3 @@
-import LogInOut from '../app/components/LogInOut';
 import SimpleLogin from "@/app/components/SimpleLogin"
 
 export default function HomePage() {

--- a/app/page.js
+++ b/app/page.js
@@ -1,5 +1,5 @@
 import LogInOut from '../app/components/LogInOut';
-import SimpleLogin from "./components/SimpleLogin"
+import SimpleLogin from "@/app/components/SimpleLogin"
 
 export default function HomePage() {
   return <SimpleLogin />;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+import path from "path";
+
+const nextConfig = {
+    webpack: (config) => {
+        config.resolve.alias = {
+            ...config.resolve.alias,
+            "@": path.resolve("./"), // For "@/..."
+        };
+        return config;
+    },
+};
 
 export default nextConfig;


### PR DESCRIPTION
Dadurch ist es einfacher, die Dateien zu verschieben, weil die Pfade bei Seiten nicht mehr angepasst werden müssen.
Außerdem wurden ungenutzte "imports" entfernt, weil nicht benötigt und so die Dateien aufgeräumter sind.

Änderungen soweit auch getestet, geht alles.