### PR TITLE
Add workflow needed approvals

### DIFF
--- a/.github/workflows/EnforceDynamicApprovals.yml
+++ b/.github/workflows/EnforceDynamicApprovals.yml
@@ -1,0 +1,63 @@
+name: "Enforce Dynamic Approvals"
+
+on:
+  pull_request:
+    branches:
+      - main
+      - development
+    types:
+      - opened
+      - synchronize
+      - edited
+  pull_request_review:
+    types:
+      - submitted # Trigger when a review (Approval) is submitted.
+
+jobs:
+  enforce-approvals:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Count changed files
+        id: file_count
+        run: |
+          FILE_COUNT=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | wc -l)
+          echo "Files changed: $FILE_COUNT"
+          echo "::set-output name=files_changed::$FILE_COUNT"
+
+      - name: Get number of approvals
+        id: approvals
+        run: |
+          APPROVALS=$(gh pr view ${{ github.event.pull_request.number }} --json reviews --jq '.reviews | map(select(.state == "APPROVED")) | length')
+          echo "Approvals: $APPROVALS"
+          echo "::set-output name=approvals::$APPROVALS"
+
+      - name: Check if PR should be blocked
+        id: check_block
+        run: |
+          FILE_COUNT=${{ steps.file_count.outputs.files_changed }}
+          APPROVALS=${{ steps.approvals.outputs.approvals }}
+          
+          if [ "$FILE_COUNT" -lt 10 ]; then
+            REQUIRED_APPROVALS=1
+          else
+            REQUIRED_APPROVALS=2
+          fi
+
+          echo "Files changed: $FILE_COUNT, Approvals: $APPROVALS, Required approvals: $REQUIRED_APPROVALS"
+
+          # If not enough approvals, block merge
+          if [ "$APPROVALS" -lt "$REQUIRED_APPROVALS" ]; then
+            echo "::set-output name=merge_block::true"
+          else
+            echo "::set-output name=merge_block::false"
+          fi
+
+      - name: Block merge if not enough approvals
+        if: ${{ steps.check_block.outputs.merge_block == 'true' }}
+        run: |
+          echo "Merge is blocked: Not enough approvals."
+          exit 1

--- a/.github/workflows/enforceDynamicApprovals.yml
+++ b/.github/workflows/enforceDynamicApprovals.yml
@@ -1,14 +1,6 @@
 name: "Enforce Dynamic Approvals"
 
 on:
-  pull_request:
-    branches:
-      - main
-      - development
-    types:
-      - opened
-      - synchronize
-      - edited
   pull_request_review:
     types:
       - submitted # Trigger when a review (Approval) is submitted.
@@ -16,6 +8,7 @@ on:
 jobs:
   enforce-approvals:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'development' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/enforceDynamicApprovals.yml
+++ b/.github/workflows/enforceDynamicApprovals.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Get number of approvals
         id: approvals
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           APPROVALS=$(gh pr view ${{ github.event.pull_request.number }} --json reviews --jq '.reviews | map(select(.state == "APPROVED")) | length')
           echo "Approvals: $APPROVALS"


### PR DESCRIPTION
Es wurde eine Github Action hinzugefügt.
Wenn 10 oder mehr Dateien in einem Pull Request geändert wurden, dann müssen mindestens zwei Reviewer ihr Approval geben.
Die Anzahlen können im Code recht einfach geändert werden, wenn wir von 10 auf 15 oder so erhöhen wollen.

Diese Action muss in Rules in den Einstellungen vom Repository nicht direkt eingebunden werden, da sie sich selbst triggert. Es muss jedoch eingestellt sein, dass die Checks erfolgreich sein müssen.