### PR TITLE
fixed recursive self include

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@mui/material-nextjs": "^6.1.6",
     "@mui/x-date-pickers": "^7.24.0",
     "@mui/x-date-pickers-pro": "^7.24.0",
-    "appointment-organizer-frontend": "file:",
     "file-saver": "^2.0.5",
     "jspdf": "^2.5.2",
     "leaflet": "^1.9.4",


### PR DESCRIPTION
In der package.json Datei war fälschlicherweise das appointment-organizer-frontend eingebunden. Somit hat sich bei npm install die Ordnerstruktur rekursiv eingebunden. Das wurde behoben.